### PR TITLE
Fix alignment in leaderboard (responsively)

### DIFF
--- a/style.css
+++ b/style.css
@@ -365,20 +365,32 @@ a {
   }
 }
 
-.leaderboard .handle {
-  padding: 0 250px;
+.leaderboard tr th:first-child,
+.leaderboard tr td:first-child {
+  text-align: right;
+  padding-left: 13px;
 }
 
-.leaderboard td,th {
-  text-align: center;
+.leaderboard tr td:first-child {
+  padding-right: 14px;
+}
+
+
+.leaderboard .handle {
+  padding-left: 230px;
+  padding-right: 130px;
+  text-align: left;
+}
+
+.leaderboard tr th:nth-child(3),
+.leaderboard tr td:nth-child(3) {
+  text-align: right;
+  padding-right: 16px;
 }
 
 .leaderboard {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   border-collapse: collapse;
+  width: 100%;
   margin: 25px 0;
   font-size: 1.05em;
   min-width: 400px;
@@ -427,14 +439,24 @@ a {
 /* Responsive Leaderboard */
 
 @media screen and (max-width: 960px) {
-  .leaderboard .handle {
-    padding: 0 30px;
-  }
-
   .leaderboard {
     margin: 30px 0;
     font-size: 1.05em;
     min-width: 10px;
+  }
+
+  .leaderboard .handle {
+    padding-left: 24px;
+    padding-right: 2px;
+  }
+
+  .leaderboard th,
+  .leaderboard td {
+    padding: 14px 6px;
+  }
+
+  .leaderboard tr td:first-child {
+    padding-right: 9px;
   }
 }
 


### PR DESCRIPTION
# Fix alignment in leaderboard (responsively)
Resolves #77: **Fix alignment on participants**

## Modifications
- `style.css` modified to fix width of each column in the table.
- The positions are aligned to the right within the first column.
- The names start from the same distance from the left in each row.
- The scores are aligned to the right.
- The final version is made responsive using `@media` queries.

## Comparison
- Previous format:
  | Desktop | Mobile |
  |:---:|:---:|
  |  ![image](https://user-images.githubusercontent.com/30315706/103146826-c3b30580-4774-11eb-98ac-a9077095e637.png)  | ![image](https://user-images.githubusercontent.com/30315706/103146830-dd544d00-4774-11eb-9502-ec6cad23013b.png)  |
- New format:
  | Desktop | Mobile |
  |:---:|:---:|
  |  ![image](https://user-images.githubusercontent.com/30315706/103146841-04ab1a00-4775-11eb-9779-0575010c064d.png)  |  ![image](https://user-images.githubusercontent.com/30315706/103146853-18ef1700-4775-11eb-99a5-b655b4a6c5d3.png) |

## Additional Information
After the update in #79, the result would be as follows:
| Desktop | Mobile |
|:---:|:---:|
|  ![image](https://user-images.githubusercontent.com/30315706/103147037-e3e3c400-4776-11eb-9b86-dfe0fa9dec15.png)  |  ![image](https://user-images.githubusercontent.com/30315706/103147043-f231e000-4776-11eb-85c6-6cc5f4a33eda.png)  |