### PR TITLE
Add GitHub profile pictures to leaderboard

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -130,7 +130,14 @@
                   }
                   table += '<tr>';
                   table += '<td>'+pos+'</td>';
-                  table += '<td class=\'handle\'><a href=\'https://github.com/'+sortedData[i].username+'\' target=\'_blank\'>'+sortedData[i].username+'</a></td>';
+                  table += (
+                    '<td class=\'handle\'><a href=\'https://github.com/'
+                      + sortedData[i].username
+                      + '\' target=\'_blank\'>'
+                      + `<img style='width: 22px; border-radius: 100%;' src='https://avatars.githubusercontent.com/${sortedData[i].username}' alt=${sortedData[i].username} />&nbsp;`
+                      + sortedData[i].username
+                      + '</a></td>'
+                  );
                   table += '<td>'+sortedData[i].score+'</td>';
                   table += '</tr>';
                 }


### PR DESCRIPTION
# Add GitHub profile pictures to leaderboard
Resolves #76: **Show avatars in leaderboard**

## Modifications
- Added `<img />` tag to leaderboard-generation script.
- Use GitHub's Avatar API to obtain avatar URL.
- Display avatar just before the username inside `.handle`.

## Comparison
- Previous format:
  | Desktop | Mobile |
  |:---:|:---:|
  |  ![image](https://user-images.githubusercontent.com/30315706/103146826-c3b30580-4774-11eb-98ac-a9077095e637.png)  | ![image](https://user-images.githubusercontent.com/30315706/103146830-dd544d00-4774-11eb-9502-ec6cad23013b.png)  |
- New format:
  | Desktop | Mobile |
  |:---:|:---:|
  |  ![image](https://user-images.githubusercontent.com/30315706/103146919-fa3d5000-4775-11eb-8b73-00badd416a0b.png)  |  ![image](https://user-images.githubusercontent.com/30315706/103146925-0aedc600-4776-11eb-9773-09039101bdd2.png)  |

# Additional Information
- For users who don't have a profile picture, their default GitHub placeholder will be displayed.
- After the update in #78, the result would be as follows:
  | Desktop | Mobile |
  |:---:|:---:|
  |  ![image](https://user-images.githubusercontent.com/30315706/103147037-e3e3c400-4776-11eb-9b86-dfe0fa9dec15.png)  |  ![image](https://user-images.githubusercontent.com/30315706/103147043-f231e000-4776-11eb-85c6-6cc5f4a33eda.png)  |